### PR TITLE
report-missing-inputs: treat empty inputs as unset

### DIFF
--- a/scripts/report-missing-inputs.pl
+++ b/scripts/report-missing-inputs.pl
@@ -31,7 +31,7 @@ while (<INPUT>) {
         if (/^  (\S+):/) {
             $key = $1;
         } elsif (/^    required: true/) {
-            push @required, $key unless %inputs && defined $inputs{$key};
+            push @required, $key unless %inputs && defined $inputs{$key} && $inputs{$key} =~ /./;
         }
     }
 }


### PR DESCRIPTION
Note that missing secrets are a common case of empty inputs