### PR TITLE
Update prettier entrypoint.sh to consider dry run

### DIFF
--- a/prettier/action.yml
+++ b/prettier/action.yml
@@ -39,7 +39,7 @@ inputs:
     required: false
     default: "**"
   dry:
-    description: Running the script in dry mode just shows whether there are files that should be prettified or not
+    description: Run prettier in dry-run mode. Display which files are/aren't pretty and changes made by prettier in the GitHub job summary
     required: false
     default: "false"
   prettier-version:


### PR DESCRIPTION
When dry-run is set to true and we use the `--write` flag, we expect to see what files we'll need to reformat without pushing to remote. However, this requires us to commit the updated changes caused by prettier. Previously, the placement of the dry run logic was done before committing the formatted files, resulting to us not seeing the expected files format. And only using the '--write' flag will not result to a failure even if there are files that requires formatting.

By moving the logic after committing the prettier files, it will show us the comparison between two files, without pushing to remote (given that we use dry flag to true). The dry run will exit with code 1 if there are changes done to the files.

This is the following result using the `--write` flag and dry set to true; when encountering files that need formatting:
https://github.com/GarnerCorp/gala-testing/actions/runs/8802209844 

Versus when we don't have any files to format:
https://github.com/GarnerCorp/gala-testing/actions/runs/8802264992
