### PR TITLE
Match suffixes of multisuffix files

### DIFF
--- a/prettier/shell-glob-files.pl
+++ b/prettier/shell-glob-files.pl
@@ -11,12 +11,14 @@ for my $extension (split " ", $ENV{INPUT_FILE_EXTENSIONS}) {
 open my $git, "-|", "git ls-files -z";
 {
   local $/ = "\0";
+  my $sought_extensions_re = join '|', (map { s/([\\{}.\[\]])/\\$1/g; $_ } keys %supported_extensions);
   while (my $file_with_path = <$git>) {
     chomp $file_with_path;
-    my ($path, $file, $ext) = ($file_with_path =~ m<(.*/|)(?:([^/.]+)(\.[^/]+))$>);
+    my ($path, $file) = ($file_with_path =~ m<(.*/|)([^/]+)$>);
     $path = "." if $path eq "";
     $path =~ s</$><>;
-    next unless defined $supported_extensions{$ext};
+    next unless $file =~ /($sought_extensions_re)$/;
+    my $ext = $1;
     $found_extensions{$ext} = 1;
     $interesting_paths{$path} = 1;
   }


### PR DESCRIPTION
@Anu48 reported that build-actions/prettier wouldn't match `file.cy.js` based on `*.js` being a supported prettier extension. I believe this should resolve that problem.

The old code would treat `.cy.js` as the file extension and only match things explicitly based on that. The new code lets each supported extension match against the entire file name and if it hits, selects that directory as an included directory.

As prettier can support an `.js.flow` the original code wouldn't support this case if you had a file name `something.else.js.flow`, so we definitely want to change the handling to allow for that.