### PR TITLE
Add `build-args` option to image build action

### DIFF
--- a/image/action.yml
+++ b/image/action.yml
@@ -1,9 +1,9 @@
-name: 'Build Image'
-description: 'Build an image'
-author: 'GarnerCorp'
+name: "Build Image"
+description: "Build an image"
+author: "GarnerCorp"
 branding:
-  icon: 'upload'
-  color: 'yellow'
+  icon: "upload"
+  color: "yellow"
 inputs:
   container-registry:
     description: "Container Registry"
@@ -44,13 +44,16 @@ inputs:
   build-context:
     description: "The context for the docker"
     required: false
+  build-args:
+    description: "A comma separated list of build arguments to pass as the --build-arg flag to docker build"
+    required: false
 outputs:
   image:
     description: "Generated image reference"
     value: ${{ steps.build-and-push-image.outputs.image }}
 
 runs:
-  using: 'composite'
+  using: "composite"
   steps:
     - name: Validate inputs
       if: ${{ !inputs.container-project || !inputs.google-credentials-json != !inputs.google-cloud-sdk-version }}
@@ -95,5 +98,6 @@ runs:
         WORKING_DIRECTORY: ${{ inputs.working-directory }}
         DOCKERFILE: ${{ inputs.dockerfile }}
         BUILD_CONTEXT: ${{ inputs.build-context || inputs.working-directory }}
+        BUILD_ARGS: ${{ inputs.build-args }}
       run: |
         "$GITHUB_ACTION_PATH/../scripts/docker-build-push.sh" -r "$REPOSITORY" -i "$IMAGE" -t "$TAG" -e "$RC" -p "$PLATFORMS" -d "$WORKING_DIRECTORY" -f "$DOCKERFILE" -c "$BUILD_CONTEXT"

--- a/image/action.yml
+++ b/image/action.yml
@@ -45,7 +45,7 @@ inputs:
     description: "The context for the docker"
     required: false
   build-args:
-    description: "A comma separated list of build arguments to pass as the --build-arg flag to docker build"
+    description: "A comma separated list of build arguments to pass as --build-arg flags to docker build"
     required: false
 outputs:
   image:

--- a/scripts/docker-build-push.sh
+++ b/scripts/docker-build-push.sh
@@ -8,11 +8,11 @@ BUILD_DIRECTORY="."
 DOCKERFILE="Dockerfile"
 
 usage() {
-  echo "Usage: $0 -r repository -i image_name [-t tag] [-e rc] [-p platform1,platform2...] [-d build_directory] [-f dockerfile] [-c build_context]"
+  echo "Usage: $0 -r repository -i image_name [-t tag] [-e rc] [-p platform1,platform2...] [-d build_directory] [-f dockerfile] [-c build_context] [-a build_args]"
   exit 1
 }
 
-while getopts r:i:t:d:f:p:e:c: opt; do
+while getopts r:i:t:d:f:p:e:c:a: opt; do
   case "$opt" in
   r)    REPOSITORY="$OPTARG";;
   i)    IMAGE="$OPTARG";;
@@ -22,6 +22,7 @@ while getopts r:i:t:d:f:p:e:c: opt; do
   p)    PLATFORMS="$OPTARG";;
   e)    RC="$OPTARG";;
   c)    BUILD_CONTEXT="$OPTARG";;
+  a)    BUILD_ARGS="$OPTARG";;
   [?])  usage;;
   esac
 done
@@ -56,6 +57,10 @@ if [ -n "$PLATFORMS" ]; then
   PLATFORM_ARGS="--platform $PLATFORMS"
 fi
 
-docker buildx build $PLATFORM_ARGS $BUILD_CONTEXT -t $PUSH_CONTEXT -f $BUILD_DIRECTORY/$DOCKERFILE --push
+if [ -n "$BUILD_ARGS" ]; then
+  BUILD_ARGS="$(echo $BUILD_ARGS | tr ',' ' ' | xargs -n 1 echo --build-arg)"
+fi
+
+echo $BUILD_ARGS | xargs docker buildx build $PLATFORM_ARGS $BUILD_CONTEXT -t $PUSH_CONTEXT -f $BUILD_DIRECTORY/$DOCKERFILE --push
 
 echo "image=$PUSH_CONTEXT" >> $GITHUB_OUTPUT


### PR DESCRIPTION
In order to use [ARG](https://docs.docker.com/reference/dockerfile/#arg) in a Dockerfile, we need to provide the `--build-arg` argument (repeatable). This PR adds an `build-args` input to the image build action that takes a comma separated key value pairs.