### PR TITLE
image: Support pkg.dev as primary publishing repository

### DIFF
--- a/.github/actions/spelling/patterns.txt
+++ b/.github/actions/spelling/patterns.txt
@@ -1,5 +1,8 @@
 # See https://github.com/check-spelling/check-spelling/wiki/Configuration-Examples:-patterns
 
+# regex word breaks
+\\b(?=[a-z])
+
 # program-downloader repository
 \brepository: \S+/\S+$
 

--- a/image/action.yml
+++ b/image/action.yml
@@ -80,13 +80,32 @@ runs:
         version: ${{ inputs.google-cloud-sdk-version }}
         project_id: ${{ inputs.container-project }}
 
-    - name: Configure GCloud and Docker
-      if: ${{ ! env.ACT }}
+    - name: Add google registries
       shell: bash
+      env:
+        images: >-
+          ${{ inputs.container-registry && inputs.container-project && format('{0}/{1}', inputs.container-registry, inputs.container-project) || ''}}
+          ${{ inputs.additional-image-tags }}
       run: |
-        : Configure docker gcloud credential helper if it is not already configured
-        if [ "$(jq -r '.credHelpers["gcr.io"] // empty' ~/.docker/config.json)" = '' ] ; then
-          gcloud auth configure-docker
+        : Configure docker gcloud credential helpers if they are not already configured
+        registries=$(perl -e '
+          my @images = split /\s+/, $ENV{images};
+          my %repos;
+          for my $image (@images) {
+            $image =~ s</.*><>;
+            next unless $image =~ /\bgcr\.io$|pkg\.dev$/;
+            $repos{$image} = 1;
+          }
+          print join " ", sort keys %repos;
+        ')
+        if [ -n "$registries" ]; then
+          echo ::group::Configure docker gcloud credential helpers
+          for registry in $registries; do
+            if [ "$(jq -r '.credHelpers["$registry"] // empty' ~/.docker/config.json)" = '' ] ; then
+              gcloud auth configure-docker "$registry"
+            fi
+          done
+          echo "::end"group::
         fi
 
     - name: Build and Push Image
@@ -123,25 +142,6 @@ runs:
         repository: google/go-containerregistry
         file-re: ^crane
         destination: "${{ github.workspace }}/../crane"
-
-    - name: Add registries
-      shell: bash
-      env:
-        images: ${{ inputs.additional-image-tags }}
-      run: |
-        : Add google registries
-        for artifact_registry in $(perl -e '
-          my @images = split /\s+/, $ENV{images};
-          my %repos;
-          for my $image (@images) {
-            $image =~ s</.*><>;
-            next unless $image =~ /pkg\.dev$/;
-            $repos{$image} = 1;
-          }
-          print join " ", keys %repos;
-        '); do
-          gcloud auth configure-docker "$artifact_registry"
-        done
 
     - name: Copy images
       shell: bash


### PR DESCRIPTION
- This merges the credential helper code into a single block before image building (which enables publishing to things that aren't gcr.io)
- It groups the output into a group so it can be collapsed
- It sorts the registries so that the output is stable
- It enables only the gcr.io registries that are being used to be added (instead of a larger set)
