### PR TITLE
copy-image: new action; deploy: add commit-message-suffix; prettier: fix commit-options + implement check-paths; *: clarify delimiters

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,4 @@ Actions for building workflows to build/publish images
 - [docker-logs](docker-logs/action.yml)
 - [configure-google-docker](configure-google-docker/action.yml)
 - [tag-images](tag-images/action.yml)
+- [copy-image](copy-image/action.yml)

--- a/configure-google-docker/action.yml
+++ b/configure-google-docker/action.yml
@@ -6,10 +6,10 @@ branding:
   color: "blue"
 inputs:
   container-registries:
-    description: "Container Registries"
+    description: "Container Registries (space delimited)"
     required: false
   images:
-    description: "Image urls"
+    description: "Image URLs (space delimited)"
     required: false
 
 runs:

--- a/copy-image/action.yml
+++ b/copy-image/action.yml
@@ -1,0 +1,68 @@
+name: "Copy Image"
+description: "Copy image to other repositories"
+author: "GarnerCorp"
+branding:
+  icon: "copy"
+  color: "green"
+inputs:
+  source:
+    description: "Source image"
+    required: true
+  destinations:
+    description: "Destination image names (space delimited)"
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Validate inputs
+      if: ${{ !inputs.source || !inputs.destinations }}
+      shell: bash
+      env:
+        INPUTS: ${{ toJSON(inputs) }}
+      run: |
+        "${{ github.action_path }}/../scripts/report-missing-inputs.pl"
+
+    - name: Add google registries
+      shell: bash
+      env:
+        registries: >-
+          ${{ inputs.source }}
+          ${{ inputs.destinations }}
+      run: |
+        : Configure docker gcloud credential helpers if they are not already configured
+        "$GITHUB_ACTION_PATH/../scripts/gcloud-auth-configure-docker.sh"
+
+    - name: Check for crane
+      id: crane
+      shell: bash
+      run: |
+        : Check for crane
+        if [ ! -e $GITHUB_WORKSPACE/../crane ]; then
+          echo "needed=1" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Install crane
+      if: ${{ steps.crane.outputs.needed }}
+      id: install-crane
+      uses: check-spelling/gh-program-downloader@v0.0.1
+      with:
+        repository: google/go-containerregistry
+        file-re: ^crane
+        destination: "${{ github.workspace }}/../crane"
+
+    - name: Copy image
+      shell: bash
+      env:
+        source: ${{ inputs.source }}
+        destinations: ${{ inputs.destinations }}
+      run: |
+        : Copy images
+        (
+          echo '# Copied images'
+          echo
+        ) >> "$GITHUB_STEP_SUMMARY"
+        for destination in $destinations; do
+          $GITHUB_WORKSPACE/../crane copy "$source" "$destination"
+          echo "* [$destination](https://$destination)" >> "$GITHUB_STEP_SUMMARY"
+        done

--- a/deploy/action.yml
+++ b/deploy/action.yml
@@ -44,6 +44,9 @@ inputs:
     description: Default branch
     default: master
     required: false
+  commit-message-suffix:
+    description: Text to append to commit message
+    required: false
 
 runs:
   using: 'composite'
@@ -87,6 +90,7 @@ runs:
         REPO_URL: ${{ github.event.repository.html_url }}
         BRANCH: ${{ github.head_ref || github.ref_name }}
         DEFAULT_BRANCH: ${{ inputs.default-branch }}
+        COMMIT_MESSAGE_SUFFIX: ${{ inputs.commit-message-suffix }}
       working-directory: _deploy/${{ inputs.working-directory }}
       run: |
         "$GITHUB_ACTION_PATH/commit-latest-versions.sh"

--- a/deploy/commit-latest-versions.sh
+++ b/deploy/commit-latest-versions.sh
@@ -55,6 +55,8 @@ fi
 git commit -m "$prefix$commitInfo
 
 $COMMIT_URL
+
+$COMMIT_MESSAGE_SUFFIX
 "
 
 git push origin HEAD ||

--- a/image/action.yml
+++ b/image/action.yml
@@ -13,7 +13,7 @@ inputs:
     description: "Path within container registry for team"
     required: true
   platforms:
-    description: "The platforms for which to build the image"
+    description: "The platforms for which to build the image (comma delimited)"
     default: "linux/amd64,linux/arm64"
     required: false
   working-directory:
@@ -42,13 +42,13 @@ inputs:
     description: "Tag used for release candidates"
     required: false
   additional-image-tags:
-    description: "Copy image to these additional tags (possibly in other repositories)"
+    description: "Copy image to these additional tags (space delimited; possibly in other repositories)"
     required: false
   build-context:
     description: "The context for the docker"
     required: false
   build-args:
-    description: "A comma separated list of build arguments to pass as --build-arg flags to docker build"
+    description: "Build arguments to pass as --build-arg flags to docker build (comma delimited)"
     required: false
 outputs:
   image:

--- a/prettier/action.yml
+++ b/prettier/action.yml
@@ -17,21 +17,21 @@ inputs:
     required: false
     default: "false"
   commit-options:
-    description: Commit options
+    description: Commit options (space delimited)
     required: false
   push-options:
-    description: Git push options
+    description: Git push options (space delimited)
     required: false
   file-pattern:
     description: File pattern used for `git add`, can't be used with only-changed!
     required: false
     default: "*"
   prettier-options:
-    description: Options for the `prettier` command
+    description: Options for the `prettier` command (space delimited)
     required: false
     default: "--write"
   file-extensions:
-    description: If not specified, prettier will be interrogated for supported extensions
+    description: If not specified, prettier will be interrogated for supported extensions (space delimited)
     required: false
     default: ""
   check-paths:
@@ -55,7 +55,7 @@ inputs:
     required: false
     default: "false"
   prettier-plugins:
-    description: Install Prettier plugins, i.e. `@prettier/plugin-php @prettier/plugin-other`
+    description: Install Prettier plugins, i.e. `@prettier/plugin-php @prettier/plugin-other` (space delimited)
     required: false
     default: ""
   github-token:

--- a/prettier/action.yml
+++ b/prettier/action.yml
@@ -83,7 +83,7 @@ inputs:
     required: false
     default: "true"
   update-git_blame_ignore_revs:
-    description: Where to update `.git_blame_ignore_revs`
+    description: Whether to update `.git_blame_ignore_revs`
     required: false
     default: "false"
   debug:

--- a/prettier/action.yml
+++ b/prettier/action.yml
@@ -35,9 +35,9 @@ inputs:
     required: false
     default: ""
   check-paths:
-    description:
+    description: Specific glob/paths to check (space delimited). If specified it suppresses the files to check based on file-extensions feature
     required: false
-    default: "**"
+    default: ""
   dry:
     description: Run prettier in dry-run mode. Display which files are/aren't pretty and changes made by prettier in the GitHub job summary
     required: false

--- a/prettier/entrypoint.sh
+++ b/prettier/entrypoint.sh
@@ -267,9 +267,9 @@ if _amend_commit; then
 else
   commit_canary=1
   if [ "$INPUT_COMMIT_DESCRIPTION" != "" ]; then
-    git commit -n -m "$INPUT_COMMIT_MESSAGE" -m "$INPUT_COMMIT_DESCRIPTION" ${INPUT_COMMIT_OPTIONS:+"$INPUT_COMMIT_OPTIONS"} || commit_canary=
+    git commit -n -m "$INPUT_COMMIT_MESSAGE" -m "$INPUT_COMMIT_DESCRIPTION" ${INPUT_COMMIT_OPTIONS:+$INPUT_COMMIT_OPTIONS} || commit_canary=
   else
-    git commit -n -m "$INPUT_COMMIT_MESSAGE" ${INPUT_COMMIT_OPTIONS:+"$INPUT_COMMIT_OPTIONS"} || commit_canary=
+    git commit -n -m "$INPUT_COMMIT_MESSAGE" ${INPUT_COMMIT_OPTIONS:+"INPUT_COMMIT_OPTIONS} || commit_canary=
   fi
 
   dry_run_check

--- a/scala/action.yml
+++ b/scala/action.yml
@@ -47,14 +47,14 @@ inputs:
     default: ""
     required: false
   extra-sbt-args:
-    description: "Extra arguments for sbt passed to build script via environment variable: EXTRA_SBT_ARGS"
+    description: "Extra arguments for sbt passed to build script via environment variable: EXTRA_SBT_ARGS (space delimited)"
     default: ""
     required: false
   build-script:
     description: "Script used to build scala project"
     required: false
   build-script-args:
-    description: "Required args for build-script"
+    description: "Required args for build-script (space delimited)"
     required: false
   google-credentials-json:
     description: "Google Service Account JSON file"
@@ -66,7 +66,7 @@ inputs:
     description: "Path within container registry for team"
     required: false
   artifact-registries:
-    description: "Google Artifact Registries that may need docker access"
+    description: "Google Artifact Registries that may need docker access (space delimited)"
     required: false
   skip-checkout:
     description: "Use files from working directory instead of checking out"

--- a/tag-images/action.yml
+++ b/tag-images/action.yml
@@ -6,13 +6,13 @@ branding:
   color: "yellow"
 inputs:
   repositories:
-    description: "Repositories"
+    description: "Repositories (space delimited)"
     required: true
   source-tag:
     description: "Source tag"
     required: true
   new-tags:
-    description: "For each repository in repositories, for each new-tag in new-tags, add new-tag to the repository with tag source-tag"
+    description: "For each repository in repositories, for each new-tag in new-tags, add new-tag to the repository with tag source-tag (space delimited)"
     required: true
 
 runs:


### PR DESCRIPTION
### Copy image

... is like tag-images except that it's specifically for copying from one place to another (e.g. from a build repository to distribution repositories). Whereas tag-images is useful for adding a `release` label to a bunch of images that have an `rc` label.

tag-images would actually let you promote a set of related objects at the same time even if they're different images.

### Deploy

It's helpful to be able to provide a bit more regularized context...

### General flow
1. build (scala or similar) 
2. test ...
3. publish (image)
4. test image
5. publish `rc` for multiple repositories (copy-image)
6. promote `release` (tag-images)
7. deploy using a CD (deploy)
