### PR TITLE
Error on incompatible peer dependency

### DIFF
--- a/yarn/reporter.json
+++ b/yarn/reporter.json
@@ -5,7 +5,7 @@
       "severity": "error",
       "pattern": [
         {
-          "regexp": "(YN00(?:0[19]|1[012567]|2[0-79]|30|4[67]|50|7[15])): │ (.*)",
+          "regexp": "(YN00(?:0[129]|1[012567]|2[0-9]|30|4[67]|50|60|7[15])): │ (.*)",
           "code": 1,
           "message": 2
         }
@@ -16,7 +16,7 @@
       "severity": "warning",
       "pattern": [
         {
-          "regexp": "(YN00(?:0[34]|1[348]|3[12]|59|6[012389]|7[267])): │ (.*)",
+          "regexp": "(YN00(?:0[34]|1[348]|3[12]|59|6[12389]|7[267])): │ (.*)",
           "code": 1,
           "message": 2
         }
@@ -30,26 +30,6 @@
           "regexp": "(YN00(?:0[25678]|19|4[89])): │ (.*)",
           "code": 1,
           "message": 2
-        }
-      ]
-    },
-    {
-      "owner": "yarn-YN0028",
-      "severity": "error",
-      "pattern": [
-        {
-          "regexp": "YN0028: │ ([A-Z].*)",
-          "message": 1
-        }
-      ]
-    },
-    {
-      "owner": "missing peer dependency",
-      "severity": "error",
-      "pattern": [
-        {
-          "regexp": "YN0002: │ ([A-Z].*)",
-          "message": 1
         }
       ]
     },


### PR DESCRIPTION
We throw errors when [missing peer dependency](https://yarnpkg.com/advanced/error-codes#yn0002---missing_peer_dependency), but we also want to do so when there is an [incompatible peer dependency](https://yarnpkg.com/advanced/error-codes#yn0060---incompatible_peer_dependency).
