### PR TITLE
google-k8s-pull-secrets: Add action for generating pull secrets

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -1,3 +1,4 @@
+accesstoken
 amd
 codependent
 corepack

--- a/README.md
+++ b/README.md
@@ -17,3 +17,4 @@ Actions for building workflows to build/publish images
 - [configure-google-docker](configure-google-docker/action.yml)
 - [tag-images](tag-images/action.yml)
 - [copy-image](copy-image/action.yml)
+- [google-k8s-pull-secrets](google-k8s-pull-secrets/action.yml)

--- a/google-k8s-pull-secrets/action.yml
+++ b/google-k8s-pull-secrets/action.yml
@@ -1,0 +1,78 @@
+name: "Set up Google Kubernetes Pull Secrets"
+description: "Create Kubernetes Pull Secrets for Google Repositories"
+author: "GarnerCorp"
+branding:
+  icon: "lock"
+  color: "blue"
+inputs:
+  images:
+    description: "Images hosted by google (space delimited)"
+    default: ""
+    required: true
+  token-file:
+    description: "File containing Google Auth Token"
+    required: true
+  namespace:
+    description: "Kubernetes namespace for credentials"
+    default: default
+    required: false
+
+outputs:
+  secret-names:
+    description: "List of created secrets"
+    value: ${{ steps.create-secrets.outputs.secrets }}
+  script:
+    description: "Script that will replace `IMAGE_PULL_CONFIG` with the secret associated with a matching `image: REGISTRY`"
+    value: ${{ steps.create-secrets.outputs.script }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Validate inputs
+      if: ${{ !inputs.images || !inputs.token-file }}
+      shell: bash
+      env:
+        INPUTS: ${{ toJSON(inputs) }}
+      run: |
+        "$GITHUB_ACTION_PATH/../scripts/report-missing-inputs.pl"
+
+    - name: Build and Push Image
+      id: create-secrets
+      shell: bash
+      env:
+        images: ${{ inputs.images }}
+        token_file: ${{ inputs.token-file }}
+        namespace: ${{ inputs.namespace }}
+      run: |
+        : Configure Kubernetes secrets
+        registries=$(perl -e '
+          my @images = split /\s+/, $ENV{images};
+          my %repos;
+          for my $image (@images) {
+            $image =~ s</.*><>;
+            next unless $image =~ /\bgcr\.io$|pkg\.dev$/;
+            $repos{$image} = 1;
+          }
+          print join " ", sort keys %repos;
+        ')
+        token=$(cat "$token_file")
+        echo "::add-mask::$token"
+        secrets=$(mktemp)
+        script=$(mktemp)
+        echo '#!/bin/sh' >> "$script"
+        chmod +x "$script"
+        for registry in $registries; do
+        (
+          export secret="$(echo "$registry" | tr '.' '-')"
+          kubectl create secret docker-registry "$secret" --docker-server $registry -n "$namespace" \
+            --docker-username oauth2accesstoken \
+            --docker-email not@val.id \
+            --docker-password="$token"
+          "$GITHUB_ACTION_PATH/maybe-fill-in-pull-secret.pl" "$registry" "$secret" >> "$script"
+          echo "$secret" >> "$secrets"
+        )
+        done
+        (
+          echo "secrets=$(cat "$secrets"|xargs)"
+          echo "script=$script"
+        ) >> "$GITHUB_OUTPUT"

--- a/google-k8s-pull-secrets/maybe-fill-in-pull-secret.pl
+++ b/google-k8s-pull-secrets/maybe-fill-in-pull-secret.pl
@@ -1,0 +1,7 @@
+#!/usr/bin/env perl
+my ($registry, $secret)=@ARGV;
+my ($d, $d1)=('\$', '$1');
+print qq<if grep -q 'image: $registry' "$d1"; then
+  perl -pi -e 's/${d}IMAGE_PULL_CONFIG/$secret/' "$d1"
+fi
+>;


### PR DESCRIPTION
This lets consumers automatically create `docker-registry` secrets in a namespace based on provided images.

Secret names are predictable (registry name with `.` replaced by `-`), and are available as an output.

There's a generated script (available as an output) that can be used to replace `$IMAGE_PULL_CONFIG` with corresponding generated secrets for k8s yaml files where the `image: ...` precedes `$IMAGE_PULL_CONFIG`.