### PR TITLE
deploy: Add inputs.sha-prefix

### DIFF
--- a/deploy/action.yml
+++ b/deploy/action.yml
@@ -30,6 +30,9 @@ inputs:
   project-pretty:
     description: Project name for commit message
     required: false
+  sha-prefix:
+    description: Prefix for image tag
+    required: false
   sha-suffix:
     description: Suffix for image tag
     required: false
@@ -83,6 +86,7 @@ runs:
         GIT_MAIL: ${{ inputs.mail }}
         PROJECT_PRETTY: ${{ inputs.project-pretty }}
         HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        SHA_PREFIX: ${{ inputs.sha-prefix }}
         SHA_SUFFIX: ${{ inputs.sha-suffix }}
         SHA_FORMATTER: ${{ inputs.sha-formatter }}
         VERSION_FILE: ${{ inputs.version-file }}

--- a/deploy/commit-latest-versions.sh
+++ b/deploy/commit-latest-versions.sh
@@ -35,7 +35,7 @@ fi
   if [ -n "$SHA_FORMATTER" ]; then
     eval $SHA_FORMATTER
   else
-    echo -n "$HEAD_SHA$SHA_SUFFIX"
+    echo -n "$SHA_PREFIX$HEAD_SHA$SHA_SUFFIX"
   fi
 ) > "$VERSION_FILE"
 


### PR DESCRIPTION
pkg.dev prefers image tag prefixes over suffixes, and there's no particular reason not to support both.