### PR TITLE
prettier: dynamically adjust backticks for github step summary

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -1,0 +1,1 @@
+backticks


### PR DESCRIPTION
The `diff` output from `prettier` will sometimes include context lines that look like:

````
     ```
````

It's important for the prettier summary not to be terminated by those contextual backticks