### PR TITLE
Add check-graphql-tag

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -1,10 +1,12 @@
 accesstoken
+apollographql
 codependent
 codesandbox
 containerregistry
 cred
 ENAMETOOLONG
 garnercorp
+graphql
 javaagent
 jmx
 jqlang

--- a/README.md
+++ b/README.md
@@ -22,3 +22,4 @@ Actions for building workflows to build/publish images
 - [install-package-manager](install-package-manager/action.yml)
 - [regression-tests](regression-tests/action.yml)
 - [report-missing-inputs](report-missing-inputs/action.yml)
+- [check-graphql-tag](check-graphql-tag/action.yml)

--- a/check-graphql-tag/action.yml
+++ b/check-graphql-tag/action.yml
@@ -1,0 +1,32 @@
+name: Check apollographql/graphql-tag
+description: Check for duplicate fragment definitions
+
+author: 'GarnerCorp'
+
+inputs:
+  file-pattern:
+    description: File pattern used for `git ls-files` to select files to check
+    required: false
+    default: "*.ts"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Add problem matchers
+      shell: bash
+      run: |
+        : Add problem matchers
+        $GITHUB_ACTION_PATH/../scripts/add-matchers.sh
+
+    - name: Check for duplicate fragment definitions
+      shell: bash
+      run: |
+        : Check for duplicate fragment definitions
+        git ls-files -- "${INPUT_FILE_PATTERN:-.}" -z |
+          "$GITHUB_ACTION_PATH/check-graphql-tags.pl"
+      env:
+        INPUT_FILE_PATTERN: ${{ inputs.file-pattern }}
+
+branding:
+  icon: "shopping-cart"
+  color: "yellow"

--- a/check-graphql-tag/check-graphql-tags.pl
+++ b/check-graphql-tag/check-graphql-tags.pl
@@ -1,0 +1,89 @@
+#!/usr/bin/env perl
+
+our %files;
+our %fragments;
+our %fragment_map;
+
+sub scan_file {
+  my ($current_file) = @_;
+  open my $fh, '<', $current_file or return;
+  our %files;
+  our %fragments;
+  while (<$fh>) {
+    next unless /^\s*fragment\s+(\w+)\s+on\b/;
+    $fragments{$1}++;
+    $files{$current_file} = 1;
+  }
+  close $fh;
+}
+
+sub get_files {
+  local $/ = "\0";
+  my @to_scan;
+  while (<>) {
+    chomp;
+    push @to_scan, $_;
+  }
+  return @to_scan;
+}
+
+sub find_duplicated_fragments {
+  my @duplicated_fragments = grep {$fragments{$_} > 1} keys %fragments;
+  exit 0 unless @duplicated_fragments;
+  my $pattern = '^\s*(fragment\s+(?:'.(join "|", @duplicated_fragments).'))\b';
+  for my $file (keys %files) {
+    open my $has_fragments_fh, q(<), $file or do {
+      warn "could not open $file: $!";
+      next;
+    };
+    while (<$has_fragments_fh>) {
+      if (/$pattern/) {
+         my ($b, $e) = ($-[1] + 1, $+[1] + 1);
+         my ($fragment, $location) = ($1, "$file:$.:$b:$e");
+         print "$location duplicate fragment: $fragment\n";
+         my @fragment_list = @{$fragment_map{$fragment}};
+         push @fragment_list, $location;
+         $fragment_map{$fragment} = \@fragment_list;
+      }
+    }
+    close $has_fragments_fh;
+  }
+}
+
+sub report_summary {
+  my $summary = $ENV{GITHUB_STEP_SUMMARY};
+  exit +1 unless defined $summary;
+
+  die "Failed to append to $summary: $!" unless open my $output, '>>', $summary;
+
+  print $output q<## Duplicate graphql-tag fragments detected
+
+[apollographql/graphql-tag](https://github.com/apollographql/graphql-tag/) doesn't like this.
+For more information, see: https://www.apollographql.com/docs/react/data/fragments#unique-names
+
+>;
+
+  our %fragment_map;
+  for my $fragment (keys %fragment_map) {
+    print $output "### $fragment
+
+File|Line|Start|End
+-|-|-|-
+";
+    my @fragment_list = @{$fragment_map{$fragment}};
+    for my $location (@fragment_list) {
+      $location =~ s/:/|/g;
+      print $output "$location\n";
+    }
+    print $output "\n";
+  }
+  close $output;
+}
+
+for my $file (get_files()) {
+  scan_file($file);
+}
+
+find_duplicated_fragments();
+report_summary();
+exit 1;

--- a/check-graphql-tag/reporter.json
+++ b/check-graphql-tag/reporter.json
@@ -1,0 +1,19 @@
+{
+  "problemMatcher": [
+    {
+      "owner": "graphql-tag-duplicate",
+      "severity": "error",
+      "pattern": [
+        {
+          "regexp": "(.*?):(\\d+):(\\d+):(\\d+) ((duplicate fragment): .*)",
+          "file": 1,
+          "line": 2,
+          "column": 3,
+          "endColumn": 4,
+          "message": 5,
+          "code": 6
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This action checks for things that would trigger: https://www.apollographql.com/docs/react/data/fragments#unique-names

In most cases these mistakes can be trivially detected at compile time, as here. So let's guard against that instead of waiting for a runtime complaint.