### PR TITLE
Update google cloud auth

### DIFF
--- a/image/action.yml
+++ b/image/action.yml
@@ -23,12 +23,12 @@ inputs:
     description: "Name of Dockerfile"
     default: "Dockerfile"
     required: false
-  google-credentials-json:
-    description: "Google Service Account JSON file"
+  service-account:
+    description: "Service Account for Google Cloud Auth"
     default: ""
     required: false
-  google-cloud-sdk-version:
-    description: "Google Cloud SDK version"
+  workload-identity-provider:
+    description: "Workload Identity Provider for Google Cloud Auth"
     default: ""
     required: false
   image-name:
@@ -61,25 +61,19 @@ runs:
   using: "composite"
   steps:
     - name: Validate inputs
-      if: ${{ !inputs.container-project || !inputs.google-credentials-json != !inputs.google-cloud-sdk-version }}
+      if: ${{ !inputs.container-project || !inputs.service-account != !inputs.workload-identity-provider }}
       uses: $/report-missing-inputs
       with:
         inputs: ${{ toJSON(inputs) }}
         action-path: ${{ github.action_path }}
-        codependent: '[ [ "google-cloud-sdk-version", "google-credentials-json" ] ]'
+        codependent: '[ [ "service-account", "workload-identity-provider" ] ]'
 
     - name: "Google Auth"
       uses: google-github-actions/auth@v3
-      if: ${{ inputs.google-credentials-json && inputs.google-cloud-sdk-version && ! env.ACT }}
+      if: ${{ inputs.service-account && inputs.workload-identity-provider && ! env.ACT }}
       with:
-        credentials_json: "${{ inputs.google-credentials-json }}"
-
-    - name: Set up Cloud SDK
-      uses: google-github-actions/setup-gcloud@v3
-      if: ${{ inputs.google-credentials-json && inputs.google-cloud-sdk-version && ! env.ACT }}
-      with:
-        version: ${{ inputs.google-cloud-sdk-version }}
-        project_id: ${{ inputs.container-project }}
+        service_account: "${{ inputs.service-account }}"
+        workload_identity_provider: "${{ inputs.workload-identity-provider }}"
 
     - name: Add google registries
       shell: bash

--- a/scala/action.yml
+++ b/scala/action.yml
@@ -52,18 +52,6 @@ inputs:
   build-script-args:
     description: "Required args for build-script (space delimited)"
     required: false
-  google-credentials-json:
-    description: "Google Service Account JSON file"
-    required: false
-  google-cloud-sdk-version:
-    description: "Google Cloud SDK version"
-    required: false
-  container-project:
-    description: "Path within container registry for team"
-    required: false
-  artifact-registries:
-    description: "Google Artifact Registries that may need docker access (space delimited)"
-    required: false
   skip-checkout:
     description: "Use files from working directory instead of checking out"
     required: false
@@ -72,39 +60,16 @@ runs:
   using: 'composite'
   steps:
     - name: Validate inputs
-      if: ${{ !inputs.google-credentials-json != !inputs.google-cloud-sdk-version || !inputs.maven-username != !inputs.maven-password }}
+      if: ${{ !inputs.maven-username != !inputs.maven-password }}
       uses: $/report-missing-inputs
       with:
         inputs: ${{ toJSON(inputs) }}
         action-path: ${{ github.action_path }}
-        codependent: '[ [ "google-cloud-sdk-version", "google-credentials-json" ], [ "maven-username", "maven-password" ] ]'
+        codependent: '[ [ "maven-username", "maven-password" ] ]'
 
     - name: Checkout
       if: ${{ ! inputs.skip-checkout }}
       uses: actions/checkout@v7
-
-    - name: "Google Auth"
-      uses: google-github-actions/auth@v3
-      if: ${{ inputs.google-credentials-json && inputs.google-cloud-sdk-version && ! env.ACT }}
-      with:
-        credentials_json: "${{ inputs.google-credentials-json }}"
-
-    - name: Set up Cloud SDK
-      uses: google-github-actions/setup-gcloud@v3
-      if: ${{ inputs.google-credentials-json && inputs.google-cloud-sdk-version && ! env.ACT }}
-      with:
-        version: ${{ inputs.google-cloud-sdk-version }}
-        project_id: ${{ inputs.container-project }}
-
-    - name: Add google registries
-      shell: bash
-      env:
-        registries: >-
-          ${{ inputs.artifact-registries }}
-      if: ${{ env.registries }}
-      run: |
-        : Configure docker gcloud credential helpers if they are not already configured
-        "$GITHUB_ACTION_PATH/../scripts/gcloud-auth-configure-docker.sh"
 
     - name: Install sbt
       if: ${{ env.ACT }}

--- a/scala/action.yml
+++ b/scala/action.yml
@@ -34,10 +34,6 @@ inputs:
     description: "Glob for sbt targets"
     default: "*/target"
     required: false
-  source-directory:
-    description: "Source directory within working directory"
-    default: "src"
-    required: false
   copy-prometheus-to:
     description: "Directories that need a prometheus jar"
     default: ""

--- a/scripts/gcloud-auth-configure-docker.sh
+++ b/scripts/gcloud-auth-configure-docker.sh
@@ -13,6 +13,7 @@ if [ -n "$registries" ]; then
   echo ::group::Configure docker gcloud credential helpers
   old_config=$(mktemp)
   new_config=$(mktemp)
+  temp_config=$(mktemp)
   additions=$(mktemp)
 
   trim_docker_conf_trailing_commas() {
@@ -22,7 +23,8 @@ if [ -n "$registries" ]; then
   for registry in $registries; do
     if [ "$(jq -r '.credHelpers["$registry"] // empty' ~/.docker/config.json)" = '' ] ; then
       trim_docker_conf_trailing_commas > "$old_config" || true
-      gcloud auth configure-docker "$registry" > /dev/null 2> /dev/null < /dev/null
+      jq '.credHelpers += {"'"$registry"'": "gcloud"}' ~/.docker/config.json > "$temp_config" &&
+        mv "$temp_config" ~/.docker/config.json
       trim_docker_conf_trailing_commas > "$new_config" || true
       if ! diff -q "$old_config" "$new_config" > /dev/null; then
         diff -U0 "$old_config" "$new_config" | perl -ne 'next unless /"gcloud"/ && s/^[+]([^+])/$1/; print' >> "$additions"

--- a/yarn/action.yml
+++ b/yarn/action.yml
@@ -75,12 +75,12 @@ runs:
   using: "composite"
   steps:
     - name: Validate inputs
-      if: ${{ !inputs.google-credentials-json != !inputs.google-cloud-sdk-version || !inputs.npm-username != !inputs.npm-password }}
+      if: ${{ !inputs.npm-username != !inputs.npm-password }}
       uses: $/report-missing-inputs
       with:
         inputs: ${{ toJSON(inputs) }}
         action-path: ${{ github.action_path }}
-        codependent: '[ [ "google-cloud-sdk-version", "google-credentials-json" ], [ "npm-username", "npm-password" ] ]'
+        codependent: '[ [ "npm-username", "npm-password" ] ]'
 
     - name: Checkout
       if: ${{ inputs.checkout == 'true' }}
@@ -217,25 +217,6 @@ runs:
       shell: bash
       run: ${{ inputs.yarn-lint-command }}
       working-directory: ${{ inputs.working-directory }}
-
-    - name: "Google Auth"
-      uses: google-github-actions/auth@v3
-      if: ${{ inputs.google-credentials-json && inputs.google-cloud-sdk-version && ! env.ACT }}
-      with:
-        credentials_json: "${{ inputs.google-credentials-json }}"
-
-    - name: Set up Cloud SDK
-      uses: google-github-actions/setup-gcloud@v3
-      if: ${{ inputs.google-credentials-json && inputs.google-cloud-sdk-version && ! env.ACT }}
-      with:
-        version: ${{ inputs.google-cloud-sdk-version }}
-        project_id: ${{ inputs.container-project }}
-
-    - name: Configure GCloud and Docker
-      if: ${{ inputs.google-credentials-json && inputs.google-cloud-sdk-version && ! env.ACT }}
-      shell: bash
-      run: |
-        gcloud auth configure-docker
 
     - name: Package
       if: ${{ ! inputs.skip-package }}


### PR DESCRIPTION
1. `gcloud auth configure-docker` is very slow, it's mostly just a jq operation, but the process to do it involves some expensive stuff. The actions/script was always written partially with the idea that it should be replaced -- this PR replaces it.
2. We've discontinued use of `google credentials json` in favor of `service account` + `workload identity provider` a while ago, this introduces support for it in the `image` action.
3. Remove various stale inputs/steps